### PR TITLE
 fix to allow compilation on mac os x

### DIFF
--- a/src/backend/parser/cypher_parser.c
+++ b/src/backend/parser/cypher_parser.c
@@ -120,6 +120,9 @@ void cypher_yyerror(YYLTYPE *llocp, ag_scanner_t scanner,
                     ag_scanner_errposition(*llocp, scanner)));
 }
 
+/* declaration to make mac os x compiler happy */
+int cypher_yyparse(ag_scanner_t scanner, cypher_yy_extra *extra);
+
 List *parse_cypher(const char *s)
 {
     ag_scanner_t scanner;


### PR DESCRIPTION
without this fix I see the following error:

```
 gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument  -mmacosx-version-min=10.12  -I.//src/include -I. -I./ -I/Applications/Postgres.app/Contents/Versions/11/include/postgresql/server -I/Applications/Postgres.app/Contents/Versions/11/include/postgresql/internal -I/Applications/Postgres.app/Contents/Versions/11/share/icu -I/Applications/Postgres.app/Contents/Versions/11/include/libxml2  -I/Applications/Postgres.app/Contents/Versions/11/include  -c -o src/backend/parser/cypher_parser.o src/backend/parser/cypher_parser.c
 src/backend/parser/cypher_parser.c:133:16: error: implicit declaration of function 'cypher_yyparse' is invalid in C99
       [-Werror,-Wimplicit-function-declaration]
     yyresult = cypher_yyparse(scanner, &extra);
                ^
 src/backend/parser/cypher_parser.c:133:16: note: did you mean 'cypher_yyerror'?
 src/backend/parser/cypher_parser.c:115:6: note: 'cypher_yyerror' declared here
 void cypher_yyerror(YYLTYPE *llocp, ag_scanner_t scanner,
```

my pg_config is:

```
BINDIR = /Applications/Postgres.app/Contents/Versions/11/bin
DOCDIR = /Applications/Postgres.app/Contents/Versions/11/share/doc/postgresql
HTMLDIR = /Applications/Postgres.app/Contents/Versions/11/share/doc/postgresql
INCLUDEDIR = /Applications/Postgres.app/Contents/Versions/11/include
PKGINCLUDEDIR = /Applications/Postgres.app/Contents/Versions/11/include/postgresql
INCLUDEDIR-SERVER = /Applications/Postgres.app/Contents/Versions/11/include/postgresql/server
LIBDIR = /Applications/Postgres.app/Contents/Versions/11/lib
PKGLIBDIR = /Applications/Postgres.app/Contents/Versions/11/lib/postgresql
LOCALEDIR = /Applications/Postgres.app/Contents/Versions/11/share/locale
MANDIR = /Applications/Postgres.app/Contents/Versions/11/share/man
SHAREDIR = /Applications/Postgres.app/Contents/Versions/11/share/postgresql
SYSCONFDIR = /Applications/Postgres.app/Contents/Versions/11/etc/postgresql
PGXS = /Applications/Postgres.app/Contents/Versions/11/lib/postgresql/pgxs/src/makefiles/pgxs.mk
CONFIGURE = '--prefix=/Applications/Postgres.app/Contents/Versions/11' '--with-includes=/Applications/Postgres.app/Contents/Versions/11/include' '--with-libraries=/Applications/Postgres.app/Contents/Versions/11/lib' '--enable-thread-safety' '--with-openssl' '--with-gssapi' '--with-bonjour' '--with-libxml' '--with-libxslt' '--with-perl' '--with-tcl' '--with-python' '--with-readline' '--with-uuid=e2fs' '--with-icu' 'CFLAGS= -mmacosx-version-min=10.12' 'CXXFLAGS= -mmacosx-version-min=10.12 -mmacosx-version-min=10.12' 'PKG_CONFIG_LIBDIR=/Applications/Postgres.app/Contents/Versions/11/lib/pkgconfig' 'ICU_CFLAGS=-I/Applications/Postgres.app/Contents/Versions/11/share/icu' 'ICU_LIBS=-licui18n -licuuc'
CC = gcc
CPPFLAGS = -I/Applications/Postgres.app/Contents/Versions/11/share/icu -I/Applications/Postgres.app/Contents/Versions/11/include/libxml2 -I/Applications/Postgres.app/Contents/Versions/11/include
CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument  -mmacosx-version-min=10.12
CFLAGS_SL =
LDFLAGS = -L/Applications/Postgres.app/Contents/Versions/11/lib -L/Applications/Postgres.app/Contents/Versions/11/lib -Wl,-dead_strip_dylibs
LDFLAGS_EX =
LDFLAGS_SL =
LIBS = -lpgcommon -lpgport -lxslt -lxml2 -lssl -lcrypto -lgssapi_krb5 -lz -lreadline -lm
VERSION = PostgreSQL 11.11
```

gcc version:

```
 gcc --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: x86_64-apple-darwin20.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```