### PR TITLE
fix: (driver/nodejs) fix problems that occur when an object is empty or nested.

### DIFF
--- a/drivers/nodejs/test/Agtype.test.ts
+++ b/drivers/nodejs/test/Agtype.test.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { AGTypeParse } from '../dist'
+import { AGTypeParse } from '../src'
 
 describe('Parsing', () => {
   it('Vertex', async () => {
@@ -33,6 +33,7 @@ describe('Parsing', () => {
       }))
     })))
   })
+
   it('Edge', async () => {
     expect(
       AGTypeParse('{"id": 1125899906842625, "label": "used_by", "end_id": 844424930131970, "start_id": 844424930131969, "properties": {"quantity": 1}}::edge')
@@ -44,6 +45,7 @@ describe('Parsing', () => {
       properties: new Map(Object.entries({ quantity: 1 }))
     })))
   })
+
   it('Path', async () => {
     expect(
       AGTypeParse('[{"id": 844424930131969, "label": "Part", "properties": {"part_num": "123"}}::vertex, {"id": 1125899906842625, "label": "used_by", "end_id": 844424930131970, "start_id": 844424930131969, "properties": {"quantity": 1}}::edge, {"id": 844424930131970, "label": "Part", "properties": {"part_num": "345"}}::vertex]::path')
@@ -66,5 +68,37 @@ describe('Parsing', () => {
         properties: new Map(Object.entries({ part_num: '345' }))
       }))
     ])
+  })
+
+  it('Null Properties', async () => {
+    expect(
+      AGTypeParse('{"id": 1688849860263937, "label": "car", "properties": {}}::vertex')
+    ).toStrictEqual(new Map<string, any>(Object.entries({
+      id: 1688849860263937,
+      label: 'car',
+      properties: new Map(Object.entries({}))
+    })))
+  })
+
+  it('Nested Agtype', () => {
+    expect(
+      AGTypeParse('{"id": 1688849860263937, "label": "car", "properties": {"a": {"b":{"c":{"d":[1, 2, "A"]}}}}}::vertex')
+    ).toStrictEqual(new Map<string, any>(Object.entries({
+      id: 1688849860263937,
+      label: 'car',
+      properties: new Map<string, any>(Object.entries({
+        a: new Map<string, any>(Object.entries({
+          b: new Map<string, any>(Object.entries({
+            c: new Map<string, any>(Object.entries({
+              d: [
+                1,
+                2,
+                'A'
+              ]
+            }))
+          }))
+        }))
+      }))
+    })))
   })
 })


### PR DESCRIPTION
fix problems that occur when an object is empty or nested.
It will fix following cases.



```
{"id": 1688849860263937, "label": "car", "properties": {}}::vertex
{"id": 1688849860263937, "label": "car", "properties": {"a": {"b":{"c":{"d":[1, 2, "A"]}}}}}::vertex
```

- [x] copyright header
