### PR TITLE
Fix wrong parse tree when use EXISTS PATTERN

### DIFF
--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -890,6 +890,94 @@ $$) AS (i agtype);
 (3 rows)
 
 --
+-- 140
+--
+-- Clean up
+SELECT DISTINCT * FROM cypher('cypher_match', $$
+    MATCH (u) DETACH DELETE (u)
+$$) AS (i agtype);
+ i 
+---
+(0 rows)
+
+-- Prepare
+SELECT * FROM cypher('cypher_match', $$
+    CREATE (u {name: "orphan"})
+    CREATE (u1 {name: "F"})-[u2:e1]->(u3 {name: "T"})
+    RETURN u1, u2, u3
+$$) as (u1 agtype, u2 agtype, u3 agtype);
+                                    u1                                     |                                                           u2                                                            |                                    u3                                     
+---------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------
+ {"id": 281474976710660, "label": "", "properties": {"name": "F"}}::vertex | {"id": 1407374883553283, "label": "e1", "end_id": 281474976710661, "start_id": 281474976710660, "properties": {}}::edge | {"id": 281474976710661, "label": "", "properties": {"name": "T"}}::vertex
+(1 row)
+
+-- Querying NOT EXISTS syntax
+SELECT * FROM cypher('cypher_match', $$
+     MATCH (f),(t)
+     WHERE NOT EXISTS((f)-[]->(t))
+     RETURN f.name, t.name
+ $$) as (f agtype, t agtype);
+    f     |    t     
+----------+----------
+ "orphan" | "orphan"
+ "orphan" | "F"
+ "orphan" | "T"
+ "F"      | "orphan"
+ "F"      | "F"
+ "T"      | "orphan"
+ "T"      | "F"
+ "T"      | "T"
+(8 rows)
+
+-- Querying EXISTS syntax
+SELECT * FROM cypher('cypher_match', $$
+    MATCH (f),(t)
+    WHERE EXISTS((f)-[]->(t))
+    RETURN f.name, t.name
+ $$) as (f agtype, t agtype);
+  f  |  t  
+-----+-----
+ "F" | "T"
+(1 row)
+
+-- Querying ALL
+SELECT * FROM cypher('cypher_match', $$
+    MATCH (f),(t)
+    WHERE NOT EXISTS((f)-[]->(t)) or true
+    RETURN f.name, t.name
+$$) as (f agtype, t agtype);
+    f     |    t     
+----------+----------
+ "orphan" | "orphan"
+ "orphan" | "F"
+ "orphan" | "T"
+ "F"      | "orphan"
+ "F"      | "F"
+ "F"      | "T"
+ "T"      | "orphan"
+ "T"      | "F"
+ "T"      | "T"
+(9 rows)
+
+-- Querying ALL
+SELECT * FROM cypher('cypher_match', $$
+    MATCH (f),(t)
+    RETURN f.name, t.name
+$$) as (f agtype, t agtype);
+    f     |    t     
+----------+----------
+ "orphan" | "orphan"
+ "orphan" | "F"
+ "orphan" | "T"
+ "F"      | "orphan"
+ "F"      | "F"
+ "F"      | "T"
+ "T"      | "orphan"
+ "T"      | "F"
+ "T"      | "T"
+(9 rows)
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);

--- a/regress/expected/cypher_match.out
+++ b/regress/expected/cypher_match.out
@@ -890,7 +890,7 @@ $$) AS (i agtype);
 (3 rows)
 
 --
--- 140
+-- JIRA: AGE2-544
 --
 -- Clean up
 SELECT DISTINCT * FROM cypher('cypher_match', $$

--- a/regress/sql/cypher_match.sql
+++ b/regress/sql/cypher_match.sql
@@ -457,6 +457,49 @@ SELECT * FROM cypher('cypher_match', $$
 $$) AS (i agtype);
 
 --
+-- JIRA: AGE2-544
+--
+
+-- Clean up
+SELECT DISTINCT * FROM cypher('cypher_match', $$
+    MATCH (u) DETACH DELETE (u)
+$$) AS (i agtype);
+
+-- Prepare
+SELECT * FROM cypher('cypher_match', $$
+    CREATE (u {name: "orphan"})
+    CREATE (u1 {name: "F"})-[u2:e1]->(u3 {name: "T"})
+    RETURN u1, u2, u3
+$$) as (u1 agtype, u2 agtype, u3 agtype);
+
+-- Querying NOT EXISTS syntax
+SELECT * FROM cypher('cypher_match', $$
+     MATCH (f),(t)
+     WHERE NOT EXISTS((f)-[]->(t))
+     RETURN f.name, t.name
+ $$) as (f agtype, t agtype);
+
+-- Querying EXISTS syntax
+SELECT * FROM cypher('cypher_match', $$
+    MATCH (f),(t)
+    WHERE EXISTS((f)-[]->(t))
+    RETURN f.name, t.name
+ $$) as (f agtype, t agtype);
+
+-- Querying ALL
+SELECT * FROM cypher('cypher_match', $$
+    MATCH (f),(t)
+    WHERE NOT EXISTS((f)-[]->(t)) or true
+    RETURN f.name, t.name
+$$) as (f agtype, t agtype);
+
+-- Querying ALL
+SELECT * FROM cypher('cypher_match', $$
+    MATCH (f),(t)
+    RETURN f.name, t.name
+$$) as (f agtype, t agtype);
+
+--
 -- Clean up
 --
 SELECT drop_graph('cypher_match', true);


### PR DESCRIPTION
#140

EXISTS PATTERN used ParseState as it was and affected the upper query.
Use a temporary ParseState to solve this problem.


Before
```
SELECT * FROM cypher('cypher_match', $$
    EXPLAIN MATCH (f),(t)
                         WHERE EXISTS((f)-[]->(t))
                         RETURN f.name, t.name
                         $$) as (f agtype, t agtype);
                                                                                  QUERY PLAN                                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Gather  (cost=1302.26..1148196.34 rows=8803401 width=64)
   Workers Planned: 2
   Params Evaluated: $0
   InitPlan 1 (returns $0)
     ->  Nested Loop  (cost=0.00..45050905.78 rows=8803418 width=0)
           Join Filter: (graphid_to_agtype(_age_default_alias_0_6.end_id) = age_id(_agtype_build_vertex(t_8.id, _label_name('18401'::oid, t_8.id), t_8.properties)))
           ->  Nested Loop  (cost=0.00..1033596.68 rows=206653 width=8)
                 Join Filter: (graphid_to_agtype(_age_default_alias_0_6.start_id) = age_id(_agtype_build_vertex(f_8.id, _label_name('18401'::oid, f_8.id), f_8.properties)))
                 ->  Append  (cost=0.00..198.80 rows=8520 width=40)
                       ->  Seq Scan on _ag_label_vertex f_8  (cost=0.00..2.20 rows=120 width=40)
                       ->  Seq Scan on v f_9  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on v1 f_10  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on v2 f_11  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on v3 f_12  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on loop f_13  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on duplicate f_14  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on other_v f_15  (cost=0.00..22.00 rows=1200 width=40)
                 ->  Materialize  (cost=0.00..147.01 rows=4851 width=16)
                       ->  Append  (cost=0.00..122.76 rows=4851 width=16)
                             ->  Seq Scan on _ag_label_edge _age_default_alias_0_6  (cost=0.00..0.00 rows=1 width=16)
                             ->  Seq Scan on e1 _age_default_alias_0_7  (cost=0.00..19.70 rows=970 width=16)
                             ->  Seq Scan on e2 _age_default_alias_0_8  (cost=0.00..19.70 rows=970 width=16)
                             ->  Seq Scan on e3 _age_default_alias_0_9  (cost=0.00..19.70 rows=970 width=16)
                             ->  Seq Scan on self _age_default_alias_0_10  (cost=0.00..19.70 rows=970 width=16)
                             ->  Seq Scan on dup_edge _age_default_alias_0_11  (cost=0.00..19.70 rows=970 width=16)
           ->  Materialize  (cost=0.00..241.40 rows=8520 width=40)
                 ->  Append  (cost=0.00..198.80 rows=8520 width=40)
                       ->  Seq Scan on _ag_label_vertex t_8  (cost=0.00..2.20 rows=120 width=40)
                       ->  Seq Scan on v t_9  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on v1 t_10  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on v2 t_11  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on v3 t_12  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on loop t_13  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on duplicate t_14  (cost=0.00..22.00 rows=1200 width=40)
                       ->  Seq Scan on other_v t_15  (cost=0.00..22.00 rows=1200 width=40)
   ->  Result  (cost=297.14..266851.12 rows=3668084 width=64)
         One-Time Filter: $0
         ->  Parallel Hash Join  (cost=297.14..211829.86 rows=3668084 width=80)
               Hash Cond: (graphid_to_agtype(_age_default_alias_0_1.end_id) = age_id(_agtype_build_vertex(t_1.id, _label_name('18401'::oid, t_1.id), t_1.properties)))
               ->  Parallel Hash Join  (cost=113.90..5102.24 rows=86105 width=48)
                     Hash Cond: (age_id(_agtype_build_vertex(f_1.id, _label_name('18401'::oid, f_1.id), f_1.properties)) = graphid_to_agtype(_age_default_alias_0_1.start_id))
                     ->  Parallel Append  (cost=0.00..138.87 rows=3550 width=40)
                           ->  Parallel Seq Scan on v f_1  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on v1 f_2  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on v2 f_3  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on v3 f_4  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on loop f_5  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on duplicate f_6  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on other_v f_7  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on _ag_label_vertex f  (cost=0.00..1.71 rows=71 width=40)
                     ->  Parallel Hash  (cost=88.63..88.63 rows=2021 width=16)
                           ->  Parallel Append  (cost=0.00..88.63 rows=2021 width=16)
                                 ->  Parallel Seq Scan on e1 _age_default_alias_0_1  (cost=0.00..15.71 rows=571 width=16)
                                 ->  Parallel Seq Scan on e2 _age_default_alias_0_2  (cost=0.00..15.71 rows=571 width=16)
                                 ->  Parallel Seq Scan on e3 _age_default_alias_0_3  (cost=0.00..15.71 rows=571 width=16)
                                 ->  Parallel Seq Scan on self _age_default_alias_0_4  (cost=0.00..15.71 rows=571 width=16)
                                 ->  Parallel Seq Scan on dup_edge _age_default_alias_0_5  (cost=0.00..15.71 rows=571 width=16)
                                 ->  Parallel Seq Scan on _ag_label_edge _age_default_alias_0  (cost=0.00..0.00 rows=1 width=16)
               ->  Parallel Hash  (cost=138.87..138.87 rows=3550 width=40)
                     ->  Parallel Append  (cost=0.00..138.87 rows=3550 width=40)
                           ->  Parallel Seq Scan on v t_1  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on v1 t_2  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on v2 t_3  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on v3 t_4  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on loop t_5  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on duplicate t_6  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on other_v t_7  (cost=0.00..17.06 rows=706 width=40)
                           ->  Parallel Seq Scan on _ag_label_vertex t  (cost=0.00..1.71 rows=71 width=40)
(68 rows)
```

After
```

SELECT * FROM cypher('cypher_match', $$
    EXPLAIN MATCH (f),(t)
                         WHERE EXISTS((f)-[]->(t))
                         RETURN f.name, t.name
                         $$) as (f agtype, t agtype);
                                                                                                                           QUERY PLAN                                                                                                                            
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.00..2660438578.90 rows=36295200 width=64)
   Join Filter: (SubPlan 1)
   ->  Append  (cost=0.00..198.80 rows=8520 width=40)
         ->  Seq Scan on _ag_label_vertex f  (cost=0.00..2.20 rows=120 width=40)
         ->  Seq Scan on v f_1  (cost=0.00..22.00 rows=1200 width=40)
         ->  Seq Scan on v1 f_2  (cost=0.00..22.00 rows=1200 width=40)
         ->  Seq Scan on v2 f_3  (cost=0.00..22.00 rows=1200 width=40)
         ->  Seq Scan on v3 f_4  (cost=0.00..22.00 rows=1200 width=40)
         ->  Seq Scan on loop f_5  (cost=0.00..22.00 rows=1200 width=40)
         ->  Seq Scan on duplicate f_6  (cost=0.00..22.00 rows=1200 width=40)
         ->  Seq Scan on other_v f_7  (cost=0.00..22.00 rows=1200 width=40)
   ->  Materialize  (cost=0.00..241.40 rows=8520 width=40)
         ->  Append  (cost=0.00..198.80 rows=8520 width=40)
               ->  Seq Scan on _ag_label_vertex t  (cost=0.00..2.20 rows=120 width=40)
               ->  Seq Scan on v t_1  (cost=0.00..22.00 rows=1200 width=40)
               ->  Seq Scan on v1 t_2  (cost=0.00..22.00 rows=1200 width=40)
               ->  Seq Scan on v2 t_3  (cost=0.00..22.00 rows=1200 width=40)
               ->  Seq Scan on v3 t_4  (cost=0.00..22.00 rows=1200 width=40)
               ->  Seq Scan on loop t_5  (cost=0.00..22.00 rows=1200 width=40)
               ->  Seq Scan on duplicate t_6  (cost=0.00..22.00 rows=1200 width=40)
               ->  Seq Scan on other_v t_7  (cost=0.00..22.00 rows=1200 width=40)
   SubPlan 1
     ->  Append  (cost=0.00..219.78 rows=6 width=0)
           ->  Seq Scan on _ag_label_edge _age_default_alias_0  (cost=0.00..0.00 rows=1 width=0)
                 Filter: ((graphid_to_agtype(start_id) = age_id(_agtype_build_vertex(f.id, _label_name('18401'::oid, f.id), f.properties))) AND (graphid_to_agtype(end_id) = age_id(_agtype_build_vertex(t.id, _label_name('18401'::oid, t.id), t.properties))))
           ->  Seq Scan on e1 _age_default_alias_0_1  (cost=0.00..43.95 rows=1 width=0)
                 Filter: ((graphid_to_agtype(start_id) = age_id(_agtype_build_vertex(f.id, _label_name('18401'::oid, f.id), f.properties))) AND (graphid_to_agtype(end_id) = age_id(_agtype_build_vertex(t.id, _label_name('18401'::oid, t.id), t.properties))))
           ->  Seq Scan on e2 _age_default_alias_0_2  (cost=0.00..43.95 rows=1 width=0)
                 Filter: ((graphid_to_agtype(start_id) = age_id(_agtype_build_vertex(f.id, _label_name('18401'::oid, f.id), f.properties))) AND (graphid_to_agtype(end_id) = age_id(_agtype_build_vertex(t.id, _label_name('18401'::oid, t.id), t.properties))))
           ->  Seq Scan on e3 _age_default_alias_0_3  (cost=0.00..43.95 rows=1 width=0)
                 Filter: ((graphid_to_agtype(start_id) = age_id(_agtype_build_vertex(f.id, _label_name('18401'::oid, f.id), f.properties))) AND (graphid_to_agtype(end_id) = age_id(_agtype_build_vertex(t.id, _label_name('18401'::oid, t.id), t.properties))))
           ->  Seq Scan on self _age_default_alias_0_4  (cost=0.00..43.95 rows=1 width=0)
                 Filter: ((graphid_to_agtype(start_id) = age_id(_agtype_build_vertex(f.id, _label_name('18401'::oid, f.id), f.properties))) AND (graphid_to_agtype(end_id) = age_id(_agtype_build_vertex(t.id, _label_name('18401'::oid, t.id), t.properties))))
           ->  Seq Scan on dup_edge _age_default_alias_0_5  (cost=0.00..43.95 rows=1 width=0)
                 Filter: ((graphid_to_agtype(start_id) = age_id(_agtype_build_vertex(f.id, _label_name('18401'::oid, f.id), f.properties))) AND (graphid_to_agtype(end_id) = age_id(_agtype_build_vertex(t.id, _label_name('18401'::oid, t.id), t.properties))))
(35 rows)

```