### PR TITLE
Fixes #204 by removing upstream clone and unneeded dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,10 @@ RUN apt-get update
 RUN apt-get install --assume-yes --no-install-recommends --no-install-suggests \
   bison \
   build-essential \
-  ca-certificates \
   flex \
-  git \
-  postgresql-plpython3-11 \
   postgresql-server-dev-11 
 
-RUN git clone https://github.com/apache/incubator-age /age 
+COPY . /age 
 RUN cd /age && make install 
 
 COPY docker-entrypoint-initdb.d/00-create-extension-age.sql /docker-entrypoint-initdb.d/00-create-extension-age.sql


### PR DESCRIPTION
This PR would address #204 where Docker Hub is building based on tag pushed, but the Dockerfile clones the head of master. The changes include:

## Changes 

- Removing unnecessary dependencies
- Changing `git clone` to COPY contents of Dockerfile's working directory (root of the repo) into the container for the build

## Testing 

- Tested using 
  * This Github repository https://github.com/VouchLLC/incubator-age 
  * This Docker Hub repo https://hub.docker.com/r/sorrell/test-age-change
- Tests consisted of
  * Creating annotated tag (1.0.1) on commit containing changes and pushing to trigger build. Image was verified to be using 1.0.1 branch.
  * Creating annotated tag (1.0.2) on commit containing changes and pushing to trigger build. Image was verified to be using 1.0.2 branch.
  * Creating annotated tag (0.9.0) on commit NOT containing changes and pushing to trigger build. Image was verified to be using master branch, matching functionality we are trying to change.